### PR TITLE
Fix closing loading modal and registration errors

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -14,7 +14,12 @@ import '../../index.css';
 import styles from './app.module.css';
 
 import { AppHeader, ProtectedRoute } from '@components';
-import { OrderInfo, IngredientDetails, Modal } from '@components';
+import {
+  OrderInfo,
+  OrderInfoModal,
+  IngredientDetails,
+  Modal
+} from '@components';
 
 const App = () => {
   const location = useLocation();
@@ -62,11 +67,7 @@ const App = () => {
         <Routes>
           <Route
             path='/feed/:number'
-            element={
-              <Modal onClose={() => window.history.back()} title=''>
-                <OrderInfo />
-              </Modal>
-            }
+            element={<OrderInfoModal onClose={() => window.history.back()} />}
           />
           <Route
             path='/ingredients/:id'
@@ -84,9 +85,7 @@ const App = () => {
             element={
               <ProtectedRoute
                 element={
-                  <Modal onClose={() => window.history.back()} title=''>
-                    <OrderInfo />
-                  </Modal>
+                  <OrderInfoModal onClose={() => window.history.back()} />
                 }
               />
             }

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,10 +1,4 @@
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  useLocation,
-  Location
-} from 'react-router-dom';
+import { Routes, Route, useLocation, Location } from 'react-router-dom';
 import {
   ConstructorPage,
   Feed,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export * from './ingredients-category';
 export * from './modal';
 export * from './order-card';
 export * from './order-info';
+export * from './order-info-modal';
 export * from './order-status';
 export * from './orders-list';
 export * from './profile-menu';

--- a/src/components/order-info-modal/index.ts
+++ b/src/components/order-info-modal/index.ts
@@ -1,0 +1,1 @@
+export { OrderInfoModal } from './order-info-modal';

--- a/src/components/order-info-modal/order-info-modal.tsx
+++ b/src/components/order-info-modal/order-info-modal.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react';
+import { Modal } from '@components';
+import { OrderInfo } from '../order-info/order-info';
+import { useSelector } from '../../services/store';
+
+export const OrderInfoModal: FC<{ onClose: () => void }> = ({ onClose }) => {
+  const orderData = useSelector((state) => state.orders.currentOrder);
+  const title = orderData ? `#${String(orderData.number).padStart(6, '0')}` : '';
+
+  return (
+    <Modal onClose={onClose} title={title}>
+      <OrderInfo />
+    </Modal>
+  );
+};

--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -15,10 +15,10 @@ export const OrderInfo: FC = () => {
   );
 
   useEffect(() => {
-    if (!orderData && number) {
+    if (number) {
       dispatch(fetchOrderInfo(Number(number)));
     }
-  }, [dispatch, number, orderData]);
+  }, [dispatch, number]);
 
   /* Готовим данные для отображения */
   const orderInfo = useMemo(() => {

--- a/src/components/ui/modal/modal.module.css
+++ b/src/components/ui/modal/modal.module.css
@@ -8,6 +8,8 @@
   padding: 40px 40px 60px;
   background-color: #1c1c21;
   border-radius: 40px;
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
   box-shadow:
     0px 24px 32px rgba(0, 0, 0, 0.04),
     0px 16px 24px rgba(0, 0, 0, 0.04),

--- a/src/components/ui/order-info/order-info.module.css
+++ b/src/components/ui/order-info/order-info.module.css
@@ -1,9 +1,14 @@
 .wrap {
   margin: 0 auto;
   width: 640px;
+  position: relative;
 }
 .number {
-  text-align: center;
+  text-align: left;
+  position: absolute;
+  top: 40px;
+  left: 40px;
+  margin: 0;
 }
 
 .status {

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,7 +11,7 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
-    <h2 className={`text text_type_digits-default mt-10 ${styles.number}`}>
+    <h2 className={`text text_type_digits-default ${styles.number}`}>
       #{String(orderInfo.number).padStart(6, '0')}
     </h2>
     <h3 className={`text text_type_main-medium  pb-3 pt-3 ${styles.header}`}>

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,7 +11,10 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
-    <h3 className={`text text_type_main-medium  pb-3 pt-10 ${styles.header}`}>
+    <h2 className={`text text_type_digits-default mt-10 ${styles.number}`}>
+      #{String(orderInfo.number).padStart(6, '0')}
+    </h2>
+    <h3 className={`text text_type_main-medium  pb-3 pt-3 ${styles.header}`}>
       {orderInfo.name}
     </h3>
     <OrderStatus status={orderInfo.status} />

--- a/src/pages/not-fount-404/index.ts
+++ b/src/pages/not-fount-404/index.ts
@@ -1,1 +1,0 @@
-export { NotFound404 } from './not-fount-404';

--- a/src/pages/not-fount-404/not-fount-404.tsx
+++ b/src/pages/not-fount-404/not-fount-404.tsx
@@ -1,7 +1,0 @@
-import { FC } from 'react';
-
-export const NotFound404: FC = () => (
-  <h3 className={`pb-6 text text_type_main-large`}>
-    Страница не найдена. Ошибка 404.
-  </h3>
-);

--- a/src/pages/profile-orders/profile-orders.tsx
+++ b/src/pages/profile-orders/profile-orders.tsx
@@ -3,6 +3,7 @@ import { TOrder } from '@utils-types';
 import { FC, useEffect } from 'react';
 import { useDispatch, useSelector } from '../../services/store';
 import { fetchUserOrders, setUserOrders } from '../../services/orders/slice';
+import { getCookie } from '../../utils/cookie';
 
 export const ProfileOrders: FC = () => {
   const dispatch = useDispatch();
@@ -12,9 +13,11 @@ export const ProfileOrders: FC = () => {
     if (!orders.length) {
       dispatch(fetchUserOrders());
     }
+    const accessToken = getCookie('accessToken');
+    const token = accessToken ? accessToken.replace('Bearer ', '') : '';
     const wsUrl =
       process.env.BURGER_API_URL?.replace('https', 'wss').replace('/api', '') +
-      `/orders?token=${localStorage.getItem('refreshToken')}`;
+      `/orders?token=${token}`;
     const socket = new WebSocket(
       wsUrl || 'wss://norma.nomoreparties.space/orders'
     );

--- a/src/pages/register/register.tsx
+++ b/src/pages/register/register.tsx
@@ -19,7 +19,8 @@ export const Register: FC = () => {
       .then(() => {
         dispatch(resetError());
         navigate('/', { replace: true });
-      });
+      })
+      .catch(() => {});
   };
 
   return (

--- a/src/services/orders/slice.ts
+++ b/src/services/orders/slice.ts
@@ -59,6 +59,7 @@ const ordersSlice = createSlice({
   reducers: {
     clearCreatedOrder: (state) => {
       state.createdOrder = null;
+      state.orderRequest = false;
     },
     setFeeds: (state, action: PayloadAction<TOrdersData>) => {
       state.feeds = action.payload;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,7 @@
       "@ui": ["src/components/ui"],
       "@ui-pages": ["src/components/ui/pages"],
       "@utils-types": ["src/utils/types"],
-      "@api": ["src/utils/burger-api.ts"],
-      "@slices": ["src/services/slices"],
-      "@selectors": ["src/services/selectors"]
+      "@api": ["src/utils/burger-api.ts"]
     }
   },
   "include": ["src"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,9 +76,7 @@ module.exports = {
       '@ui': path.resolve(__dirname, './src/components/ui'),
       '@ui-pages': path.resolve(__dirname, './src/components/ui/pages'),
       '@utils-types': path.resolve(__dirname, './src/utils/types'),
-      '@api': path.resolve(__dirname, './src/utils/burger-api.ts'),
-      '@slices': path.resolve(__dirname, './src/services/slices'),
-      '@selectors': path.resolve(__dirname, './src/services/selectors')
+      '@api': path.resolve(__dirname, './src/utils/burger-api.ts')
     }
   },
   output: {


### PR DESCRIPTION
## Summary
- allow closing the loading modal
- avoid runtime error when registration fails

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685aa28500548326aef499ab86bcdd60