### PR TITLE
Fix order details modal and registration

### DIFF
--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -15,10 +15,10 @@ export const OrderInfo: FC = () => {
   );
 
   useEffect(() => {
-    if (!orderData && number) {
+    if (number && orderData?.number !== Number(number)) {
       dispatch(fetchOrderInfo(Number(number)));
     }
-  }, [dispatch, number, orderData]);
+  }, [dispatch, number, orderData?.number]);
 
   /* Готовим данные для отображения */
   const orderInfo = useMemo(() => {

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,7 +11,10 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
-    <h3 className={`text text_type_main-medium  pb-3 pt-10 ${styles.header}`}>
+    <p className={`${styles.number} text text_type_digits-default pt-10`}>
+      #{String(orderInfo.number).padStart(6, '0')}
+    </p>
+    <h3 className={`text text_type_main-medium  pb-3 pt-6 ${styles.header}`}>
       {orderInfo.name}
     </h3>
     <OrderStatus status={orderInfo.status} />

--- a/src/pages/register/register.tsx
+++ b/src/pages/register/register.tsx
@@ -8,23 +8,30 @@ export const Register: FC = () => {
   const [userName, setUserName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const error = useSelector((state) => state.user.error);
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
+    if (!userName || !email || !password) {
+      setLocalError('Заполните все поля');
+      return;
+    }
+    setLocalError(null);
     dispatch(registerUser({ email, name: userName, password }))
       .unwrap()
       .then(() => {
         dispatch(resetError());
         navigate('/', { replace: true });
-      });
+      })
+      .catch(() => {});
   };
 
   return (
     <RegisterUI
-      errorText={error || ''}
+      errorText={localError || error || ''}
       email={email}
       userName={userName}
       password={password}


### PR DESCRIPTION
## Summary
- refetch order data when selecting different order
- show order number in OrderInfo modal
- validate registration form fields

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ab36cc47c8326bc32348eafe7277f