### PR TITLE
Fix order info refresh and registration validation

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -3,7 +3,8 @@ import {
   Routes,
   Route,
   useLocation,
-  Location
+  Location,
+  useParams
 } from 'react-router-dom';
 import {
   ConstructorPage,
@@ -21,6 +22,15 @@ import styles from './app.module.css';
 
 import { AppHeader, ProtectedRoute } from '@components';
 import { OrderInfo, IngredientDetails, Modal } from '@components';
+
+const OrderInfoModal = () => {
+  const { number } = useParams<{ number: string }>();
+  return (
+    <Modal onClose={() => window.history.back()} title={`#${number}`}>
+      <OrderInfo />
+    </Modal>
+  );
+};
 
 const App = () => {
   const location = useLocation();
@@ -66,14 +76,7 @@ const App = () => {
       </Routes>
       {background && (
         <Routes>
-          <Route
-            path='/feed/:number'
-            element={
-              <Modal onClose={() => window.history.back()} title=''>
-                <OrderInfo />
-              </Modal>
-            }
-          />
+          <Route path='/feed/:number' element={<OrderInfoModal />} />
           <Route
             path='/ingredients/:id'
             element={
@@ -87,15 +90,7 @@ const App = () => {
           />
           <Route
             path='/profile/orders/:number'
-            element={
-              <ProtectedRoute
-                element={
-                  <Modal onClose={() => window.history.back()} title=''>
-                    <OrderInfo />
-                  </Modal>
-                }
-              />
-            }
+            element={<ProtectedRoute element={<OrderInfoModal />} />}
           />
         </Routes>
       )}

--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -15,7 +15,7 @@ export const OrderInfo: FC = () => {
   );
 
   useEffect(() => {
-    if (!orderData && number) {
+    if (number && (!orderData || orderData.number !== Number(number))) {
       dispatch(fetchOrderInfo(Number(number)));
     }
   }, [dispatch, number, orderData]);

--- a/src/components/ui/order-info/order-info.module.css
+++ b/src/components/ui/order-info/order-info.module.css
@@ -2,9 +2,6 @@
   margin: 0 auto;
   width: 640px;
 }
-.number {
-  text-align: center;
-}
 
 .status {
   color: #00cccc;

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,9 +11,12 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
-    <h3 className={`text text_type_main-medium  pb-3 pt-10 ${styles.header}`}>
-      {orderInfo.name}
-    </h3>
+    <p className={`text text_type_digits-default pb-3 pt-10 ${styles.number}`}>
+      #{orderInfo.number}
+    </p>
+    <h3 className={`text text_type_main-medium pb-3 ${styles.header}`}>{
+      orderInfo.name
+    }</h3>
     <OrderStatus status={orderInfo.status} />
     <p className={`text text_type_main-medium pt-15 pb=6`}>Состав:</p>
     <ul className={`${styles.list} mb-8`}>

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,10 +11,7 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
-    <p className={`text text_type_digits-default pb-3 pt-10 ${styles.number}`}>
-      #{orderInfo.number}
-    </p>
-    <h3 className={`text text_type_main-medium pb-3 ${styles.header}`}>{
+    <h3 className={`text text_type_main-medium pt-10 pb-3 ${styles.header}`}>{
       orderInfo.name
     }</h3>
     <OrderStatus status={orderInfo.status} />

--- a/src/pages/register/register.tsx
+++ b/src/pages/register/register.tsx
@@ -8,23 +8,30 @@ export const Register: FC = () => {
   const [userName, setUserName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [localError, setLocalError] = useState('');
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const error = useSelector((state) => state.user.error);
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
+    if (!userName || !email || !password) {
+      setLocalError('Пожалуйста, заполните все поля');
+      return;
+    }
+    setLocalError('');
     dispatch(registerUser({ email, name: userName, password }))
       .unwrap()
       .then(() => {
         dispatch(resetError());
         navigate('/', { replace: true });
-      });
+      })
+      .catch(() => {});
   };
 
   return (
     <RegisterUI
-      errorText={error || ''}
+      errorText={localError || error || ''}
       email={email}
       userName={userName}
       password={password}


### PR DESCRIPTION
## Summary
- fetch new order info whenever order number changes
- show order number in the order details modal
- validate fields before sending registration request

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_685ab5d887188326aeedb64708fc71d8