### PR TITLE
Fix order modal state and registration validation

### DIFF
--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -4,7 +4,7 @@ import { Preloader } from '../ui/preloader';
 import { OrderInfoUI } from '../ui/order-info';
 import { TIngredient } from '@utils-types';
 import { useDispatch, useSelector } from '../../services/store';
-import { fetchOrderInfo } from '../../services/orders/slice';
+import { fetchOrderInfo, clearCurrentOrder } from '../../services/orders/slice';
 
 export const OrderInfo: FC = () => {
   const { number } = useParams<{ number: string }>();
@@ -15,10 +15,16 @@ export const OrderInfo: FC = () => {
   );
 
   useEffect(() => {
-    if (!orderData && number) {
+    if (number && orderData?.number !== Number(number)) {
       dispatch(fetchOrderInfo(Number(number)));
     }
-  }, [dispatch, number, orderData]);
+  }, [dispatch, number, orderData?.number]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(clearCurrentOrder());
+    };
+  }, [dispatch]);
 
   /* Готовим данные для отображения */
   const orderInfo = useMemo(() => {

--- a/src/components/ui/order-info/order-info.module.css
+++ b/src/components/ui/order-info/order-info.module.css
@@ -3,7 +3,8 @@
   width: 640px;
 }
 .number {
-  text-align: center;
+  text-align: left;
+  width: 100%;
 }
 
 .status {

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,6 +11,9 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
+    <p className={`text text_type_digits-default ${styles.number}`}>
+      #{String(orderInfo.number).padStart(6, '0')}
+    </p>
     <h3 className={`text text_type_main-medium  pb-3 pt-10 ${styles.header}`}>
       {orderInfo.name}
     </h3>

--- a/src/pages/register/register.tsx
+++ b/src/pages/register/register.tsx
@@ -8,23 +8,30 @@ export const Register: FC = () => {
   const [userName, setUserName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [formError, setFormError] = useState('');
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const error = useSelector((state) => state.user.error);
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
+    if (!userName || !email || !password) {
+      setFormError('Заполните все поля');
+      return;
+    }
+    setFormError('');
     dispatch(registerUser({ email, name: userName, password }))
       .unwrap()
       .then(() => {
         dispatch(resetError());
         navigate('/', { replace: true });
-      });
+      })
+      .catch(() => {});
   };
 
   return (
     <RegisterUI
-      errorText={error || ''}
+      errorText={error || formError}
       email={email}
       userName={userName}
       password={password}

--- a/src/services/orders/slice.ts
+++ b/src/services/orders/slice.ts
@@ -60,6 +60,9 @@ const ordersSlice = createSlice({
     clearCreatedOrder: (state) => {
       state.createdOrder = null;
     },
+    clearCurrentOrder: (state) => {
+      state.currentOrder = null;
+    },
     setFeeds: (state, action: PayloadAction<TOrdersData>) => {
       state.feeds = action.payload;
     },
@@ -113,7 +116,7 @@ const ordersSlice = createSlice({
   }
 });
 
-export const { clearCreatedOrder, setFeeds, setUserOrders } =
+export const { clearCreatedOrder, clearCurrentOrder, setFeeds, setUserOrders } =
   ordersSlice.actions;
 
 export default ordersSlice.reducer;


### PR DESCRIPTION
## Summary
- reset current order when modal closes
- show correct order info when switching between orders
- display order number in modal header
- handle empty registration fields and promise rejection

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685abc77f600832681e7c38b3a774b4f