### PR TITLE
Fix order modal updates and registration validation

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -20,7 +20,12 @@ import '../../index.css';
 import styles from './app.module.css';
 
 import { AppHeader, ProtectedRoute } from '@components';
-import { OrderInfo, IngredientDetails, Modal } from '@components';
+import {
+  OrderInfo,
+  OrderInfoModal,
+  IngredientDetails,
+  Modal
+} from '@components';
 
 const App = () => {
   const location = useLocation();
@@ -66,14 +71,7 @@ const App = () => {
       </Routes>
       {background && (
         <Routes>
-          <Route
-            path='/feed/:number'
-            element={
-              <Modal onClose={() => window.history.back()} title=''>
-                <OrderInfo />
-              </Modal>
-            }
-          />
+          <Route path='/feed/:number' element={<OrderInfoModal />} />
           <Route
             path='/ingredients/:id'
             element={
@@ -87,15 +85,7 @@ const App = () => {
           />
           <Route
             path='/profile/orders/:number'
-            element={
-              <ProtectedRoute
-                element={
-                  <Modal onClose={() => window.history.back()} title=''>
-                    <OrderInfo />
-                  </Modal>
-                }
-              />
-            }
+            element={<ProtectedRoute element={<OrderInfoModal />} />}
           />
         </Routes>
       )}

--- a/src/components/order-info/index.ts
+++ b/src/components/order-info/index.ts
@@ -1,1 +1,2 @@
 export { OrderInfo } from './order-info';
+export { OrderInfoModal } from './order-info-modal';

--- a/src/components/order-info/order-info-modal.tsx
+++ b/src/components/order-info/order-info-modal.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { useParams } from 'react-router-dom';
+import { Modal } from '../modal';
+import { OrderInfo } from './order-info';
+
+export const OrderInfoModal: FC = () => {
+  const { number } = useParams<{ number: string }>();
+  return (
+    <Modal onClose={() => window.history.back()} title={`#${number}`}>
+      <OrderInfo />
+    </Modal>
+  );
+};

--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -4,15 +4,27 @@ import { Preloader } from '../ui/preloader';
 import { OrderInfoUI } from '../ui/order-info';
 import { TIngredient } from '@utils-types';
 import { useDispatch, useSelector } from '../../services/store';
-import { fetchOrderInfo, clearCurrentOrder } from '../../services/orders/slice';
+import {
+  fetchOrderInfo,
+  clearCurrentOrder
+} from '../../services/orders/slice';
+import { fetchIngredients } from '../../services/ingredients/slice';
 
 export const OrderInfo: FC = () => {
   const { number } = useParams<{ number: string }>();
   const dispatch = useDispatch();
   const orderData = useSelector((state) => state.orders.currentOrder);
+  const loading = useSelector((state) => state.orders.loading);
+  const error = useSelector((state) => state.orders.error);
   const ingredients: TIngredient[] = useSelector(
     (state) => state.ingredients.items
   );
+
+  useEffect(() => {
+    if (!ingredients.length) {
+      dispatch(fetchIngredients());
+    }
+  }, [dispatch, ingredients.length]);
 
   useEffect(() => {
     if (number && (!orderData || orderData.number !== Number(number))) {
@@ -66,8 +78,12 @@ export const OrderInfo: FC = () => {
     };
   }, [orderData, ingredients]);
 
-  if (!orderInfo) {
-    return <Preloader />;
+  if (!orderInfo || loading) {
+    return error ? (
+      <p className='text text_type_main-default p-10'>{error}</p>
+    ) : (
+      <Preloader />
+    );
   }
 
   return <OrderInfoUI orderInfo={orderInfo} />;

--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -4,10 +4,7 @@ import { Preloader } from '../ui/preloader';
 import { OrderInfoUI } from '../ui/order-info';
 import { TIngredient } from '@utils-types';
 import { useDispatch, useSelector } from '../../services/store';
-import {
-  fetchOrderInfo,
-  clearCurrentOrder
-} from '../../services/orders/slice';
+import { fetchOrderInfo, clearCurrentOrder } from '../../services/orders/slice';
 
 export const OrderInfo: FC = () => {
   const { number } = useParams<{ number: string }>();

--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -4,7 +4,10 @@ import { Preloader } from '../ui/preloader';
 import { OrderInfoUI } from '../ui/order-info';
 import { TIngredient } from '@utils-types';
 import { useDispatch, useSelector } from '../../services/store';
-import { fetchOrderInfo } from '../../services/orders/slice';
+import {
+  fetchOrderInfo,
+  clearCurrentOrder
+} from '../../services/orders/slice';
 
 export const OrderInfo: FC = () => {
   const { number } = useParams<{ number: string }>();
@@ -15,9 +18,13 @@ export const OrderInfo: FC = () => {
   );
 
   useEffect(() => {
-    if (!orderData && number) {
+    if (number && (!orderData || orderData.number !== Number(number))) {
       dispatch(fetchOrderInfo(Number(number)));
     }
+
+    return () => {
+      dispatch(clearCurrentOrder());
+    };
   }, [dispatch, number, orderData]);
 
   /* Готовим данные для отображения */

--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -6,7 +6,8 @@ import { TIngredient } from '@utils-types';
 import { useDispatch, useSelector } from '../../services/store';
 import {
   fetchOrderInfo,
-  clearCurrentOrder
+  clearCurrentOrder,
+  setCurrentOrder
 } from '../../services/orders/slice';
 import { fetchIngredients } from '../../services/ingredients/slice';
 
@@ -16,6 +17,8 @@ export const OrderInfo: FC = () => {
   const orderData = useSelector((state) => state.orders.currentOrder);
   const loading = useSelector((state) => state.orders.loading);
   const error = useSelector((state) => state.orders.error);
+  const feedsOrders = useSelector((state) => state.orders.feeds?.orders);
+  const userOrders = useSelector((state) => state.orders.userOrders);
   const ingredients: TIngredient[] = useSelector(
     (state) => state.ingredients.items
   );
@@ -27,14 +30,23 @@ export const OrderInfo: FC = () => {
   }, [dispatch, ingredients.length]);
 
   useEffect(() => {
-    if (number && (!orderData || orderData.number !== Number(number))) {
-      dispatch(fetchOrderInfo(Number(number)));
+    if (number) {
+      const num = Number(number);
+      const fromStore =
+        feedsOrders?.find((o) => o.number === num) ||
+        userOrders.find((o) => o.number === num);
+
+      if (fromStore) {
+        dispatch(setCurrentOrder(fromStore));
+      } else if (!orderData || orderData.number !== num) {
+        dispatch(fetchOrderInfo(num));
+      }
     }
 
     return () => {
       dispatch(clearCurrentOrder());
     };
-  }, [dispatch, number, orderData]);
+  }, [dispatch, number, orderData, feedsOrders, userOrders]);
 
   /* Готовим данные для отображения */
   const orderInfo = useMemo(() => {

--- a/src/components/order-info/order-info.tsx
+++ b/src/components/order-info/order-info.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation, Location } from 'react-router-dom';
 import { Preloader } from '../ui/preloader';
 import { OrderInfoUI } from '../ui/order-info';
 import { TIngredient } from '@utils-types';
@@ -13,6 +13,7 @@ import { fetchIngredients } from '../../services/ingredients/slice';
 
 export const OrderInfo: FC = () => {
   const { number } = useParams<{ number: string }>();
+  const location = useLocation();
   const dispatch = useDispatch();
   const orderData = useSelector((state) => state.orders.currentOrder);
   const loading = useSelector((state) => state.orders.loading);
@@ -98,5 +99,9 @@ export const OrderInfo: FC = () => {
     );
   }
 
-  return <OrderInfoUI orderInfo={orderInfo} />;
+  const inModal = Boolean(
+    (location.state as { background?: Location })?.background
+  );
+
+  return <OrderInfoUI orderInfo={orderInfo} inModal={inModal} />;
 };

--- a/src/components/profile-menu/profile-menu.tsx
+++ b/src/components/profile-menu/profile-menu.tsx
@@ -14,7 +14,8 @@ export const ProfileMenu: FC = () => {
       .unwrap()
       .then(() => {
         navigate('/login', { replace: true });
-      });
+      })
+      .catch(() => {});
   };
 
   return <ProfileMenuUI handleLogout={handleLogout} pathname={pathname} />;

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -10,20 +10,14 @@ import { OrderInfoUIProps } from './type';
 import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
-  <div className={styles.wrap}>
-    <div
-      className='pt-10 pb-3'
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center'
-      }}
+  <div className={styles.wrap} style={{ position: 'relative' }}>
+    <p
+      className={`${styles.number} text text_type_digits-default`}
+      style={{ position: 'absolute', top: 60, left: 40 }}
     >
-      <h3 className={`text text_type_main-medium ${styles.header}`}>{orderInfo.name}</h3>
-      <p className={`${styles.number} text text_type_digits-default`}>
-        #{String(orderInfo.number).padStart(6, '0')}
-      </p>
-    </div>
+      #{String(orderInfo.number).padStart(6, '0')}
+    </p>
+    <h3 className={`text text_type_main-medium pb-3 pt-10 ${styles.header}`}>{orderInfo.name}</h3>
     <OrderStatus status={orderInfo.status} />
     <p className={`text text_type_main-medium pt-15 pb=6`}>Состав:</p>
     <ul className={`${styles.list} mb-8`}>

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,8 +11,8 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
-    <p className={`${styles.number} text text_type_digits-default pt-10`}>#
-      {orderInfo.number}
+    <p className={`${styles.number} text text_type_digits-default pt-10`}>
+      #{orderInfo.number}
     </p>
     <h3 className={`text text_type_main-medium  pb-3 pt-10 ${styles.header}`}>
       {orderInfo.name}

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,12 +11,19 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
-    <p className={`${styles.number} text text_type_digits-default pt-10`}>
-      #{orderInfo.number}
-    </p>
-    <h3 className={`text text_type_main-medium  pb-3 pt-10 ${styles.header}`}>
-      {orderInfo.name}
-    </h3>
+    <div
+      className='pt-10 pb-3'
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center'
+      }}
+    >
+      <h3 className={`text text_type_main-medium ${styles.header}`}>{orderInfo.name}</h3>
+      <p className={`${styles.number} text text_type_digits-default`}>
+        #{String(orderInfo.number).padStart(6, '0')}
+      </p>
+    </div>
     <OrderStatus status={orderInfo.status} />
     <p className={`text text_type_main-medium pt-15 pb=6`}>Состав:</p>
     <ul className={`${styles.list} mb-8`}>

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -11,6 +11,9 @@ import { OrderStatus } from '@components';
 
 export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
   <div className={styles.wrap}>
+    <p className={`${styles.number} text text_type_digits-default pt-10`}>#
+      {orderInfo.number}
+    </p>
     <h3 className={`text text_type_main-medium  pb-3 pt-10 ${styles.header}`}>
       {orderInfo.name}
     </h3>

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -9,14 +9,11 @@ import styles from './order-info.module.css';
 import { OrderInfoUIProps } from './type';
 import { OrderStatus } from '@components';
 
-export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo }) => (
-  <div className={styles.wrap} style={{ position: 'relative' }}>
-    <p
-      className={`${styles.number} text text_type_digits-default`}
-      style={{ position: 'absolute', top: 60, left: 40 }}
-    >
-      #{String(orderInfo.number).padStart(6, '0')}
-    </p>
+export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo, inModal }) => (
+  <div className={styles.wrap}>
+    {!inModal && (
+      <p className={`${styles.number} text text_type_digits-default`}>#{String(orderInfo.number).padStart(6, '0')}</p>
+    )}
     <h3 className={`text text_type_main-medium pb-3 pt-10 ${styles.header}`}>{orderInfo.name}</h3>
     <OrderStatus status={orderInfo.status} />
     <p className={`text text_type_main-medium pt-15 pb=6`}>Состав:</p>

--- a/src/components/ui/order-info/order-info.tsx
+++ b/src/components/ui/order-info/order-info.tsx
@@ -9,44 +9,52 @@ import styles from './order-info.module.css';
 import { OrderInfoUIProps } from './type';
 import { OrderStatus } from '@components';
 
-export const OrderInfoUI: FC<OrderInfoUIProps> = memo(({ orderInfo, inModal }) => (
-  <div className={styles.wrap}>
-    {!inModal && (
-      <p className={`${styles.number} text text_type_digits-default`}>#{String(orderInfo.number).padStart(6, '0')}</p>
-    )}
-    <h3 className={`text text_type_main-medium pb-3 pt-10 ${styles.header}`}>{orderInfo.name}</h3>
-    <OrderStatus status={orderInfo.status} />
-    <p className={`text text_type_main-medium pt-15 pb=6`}>Состав:</p>
-    <ul className={`${styles.list} mb-8`}>
-      {Object.values(orderInfo.ingredientsInfo).map((item, index) => (
-        <li className={`pb-4 pr-6 ${styles.item}`} key={index}>
-          <div className={styles.img_wrap}>
-            <div className={styles.border}>
-              <img
-                className={styles.img}
-                src={item.image_mobile}
-                alt={item.name}
-              />
+export const OrderInfoUI: FC<OrderInfoUIProps> = memo(
+  ({ orderInfo, inModal }) => (
+    <div className={styles.wrap}>
+      {!inModal && (
+        <p className={`${styles.number} text text_type_digits-default`}>
+          #{String(orderInfo.number).padStart(6, '0')}
+        </p>
+      )}
+      <h3 className={`text text_type_main-medium pb-3 pt-10 ${styles.header}`}>
+        {orderInfo.name}
+      </h3>
+      <OrderStatus status={orderInfo.status} />
+      <p className={`text text_type_main-medium pt-15 pb=6`}>Состав:</p>
+      <ul className={`${styles.list} mb-8`}>
+        {Object.values(orderInfo.ingredientsInfo).map((item, index) => (
+          <li className={`pb-4 pr-6 ${styles.item}`} key={index}>
+            <div className={styles.img_wrap}>
+              <div className={styles.border}>
+                <img
+                  className={styles.img}
+                  src={item.image_mobile}
+                  alt={item.name}
+                />
+              </div>
             </div>
-          </div>
-          <span className='text text_type_main-default pl-4'>{item.name}</span>
-          <span
-            className={`text text_type_digits-default pl-4 pr-4 ${styles.quantity}`}
-          >
-            {item.count} x {item.price}
-          </span>
-          <CurrencyIcon type={'primary'} />
-        </li>
-      ))}
-    </ul>
-    <div className={styles.bottom}>
-      <p className='text text_type_main-default text_color_inactive'>
-        <FormattedDate date={orderInfo.date} />
-      </p>
-      <span className={`text text_type_digits-default pr-4 ${styles.total}`}>
-        {orderInfo.total}
-      </span>
-      <CurrencyIcon type={'primary'} />
+            <span className='text text_type_main-default pl-4'>
+              {item.name}
+            </span>
+            <span
+              className={`text text_type_digits-default pl-4 pr-4 ${styles.quantity}`}
+            >
+              {item.count} x {item.price}
+            </span>
+            <CurrencyIcon type={'primary'} />
+          </li>
+        ))}
+      </ul>
+      <div className={styles.bottom}>
+        <p className='text text_type_main-default text_color_inactive'>
+          <FormattedDate date={orderInfo.date} />
+        </p>
+        <span className={`text text_type_digits-default pr-4 ${styles.total}`}>
+          {orderInfo.total}
+        </span>
+        <CurrencyIcon type={'primary'} />
+      </div>
     </div>
-  </div>
-));
+  )
+);

--- a/src/components/ui/order-info/type.ts
+++ b/src/components/ui/order-info/type.ts
@@ -2,6 +2,7 @@ import { TIngredient } from '@utils-types';
 
 export type OrderInfoUIProps = {
   orderInfo: TOrderInfo;
+  inModal?: boolean;
 };
 
 type TOrderInfo = {

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,4 +1,11 @@
-import { FC, SyntheticEvent, useState, useEffect } from 'react';
+import {
+  FC,
+  SyntheticEvent,
+  useState,
+  Dispatch,
+  SetStateAction,
+  useEffect
+} from 'react';
 import { LoginUI } from '@ui-pages';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from '../../services/store';
@@ -16,6 +23,16 @@ export const Login: FC = () => {
     dispatch(resetError());
   }, [dispatch]);
 
+  const handleEmailChange: Dispatch<SetStateAction<string>> = (value) => {
+    setEmail((prev) => (typeof value === 'function' ? value(prev) : value));
+    if (error) dispatch(resetError());
+  };
+
+  const handlePasswordChange: Dispatch<SetStateAction<string>> = (value) => {
+    setPassword((prev) => (typeof value === 'function' ? value(prev) : value));
+    if (error) dispatch(resetError());
+  };
+
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
     const from = (location.state as { from?: string })?.from || '/';
@@ -32,9 +49,9 @@ export const Login: FC = () => {
     <LoginUI
       errorText={error || ''}
       email={email}
-      setEmail={setEmail}
+      setEmail={handleEmailChange}
       password={password}
-      setPassword={setPassword}
+      setPassword={handlePasswordChange}
       handleSubmit={handleSubmit}
     />
   );

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent, useState } from 'react';
+import { FC, SyntheticEvent, useState, useEffect } from 'react';
 import { LoginUI } from '@ui-pages';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from '../../services/store';
@@ -11,6 +11,10 @@ export const Login: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const error = useSelector((state) => state.user.error);
+
+  useEffect(() => {
+    dispatch(resetError());
+  }, [dispatch]);
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -40,7 +40,16 @@ export const Profile: FC = () => {
         email: formValue.email,
         password: formValue.password || undefined
       })
-    );
+    )
+      .unwrap()
+      .then((updated) => {
+        setFormValue({
+          name: updated.name,
+          email: updated.email,
+          password: ''
+        });
+      })
+      .catch(() => {});
   };
 
   const handleCancel = (e: SyntheticEvent) => {

--- a/src/pages/register/register.tsx
+++ b/src/pages/register/register.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent, useState } from 'react';
+import { FC, SyntheticEvent, useState, Dispatch, SetStateAction } from 'react';
 import { RegisterUI } from '@ui-pages';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from '../../services/store';
@@ -30,18 +30,18 @@ export const Register: FC = () => {
       .catch(() => {});
   };
 
-  const handleEmailChange = (value: string) => {
-    setEmail(value);
+  const handleEmailChange: Dispatch<SetStateAction<string>> = (value) => {
+    setEmail((prev) => (typeof value === 'function' ? value(prev) : value));
     if (formError) setFormError('');
   };
 
-  const handlePasswordChange = (value: string) => {
-    setPassword(value);
+  const handlePasswordChange: Dispatch<SetStateAction<string>> = (value) => {
+    setPassword((prev) => (typeof value === 'function' ? value(prev) : value));
     if (formError) setFormError('');
   };
 
-  const handleUserNameChange = (value: string) => {
-    setUserName(value);
+  const handleUserNameChange: Dispatch<SetStateAction<string>> = (value) => {
+    setUserName((prev) => (typeof value === 'function' ? value(prev) : value));
     if (formError) setFormError('');
   };
 

--- a/src/pages/register/register.tsx
+++ b/src/pages/register/register.tsx
@@ -1,4 +1,11 @@
-import { FC, SyntheticEvent, useState, Dispatch, SetStateAction } from 'react';
+import {
+  FC,
+  SyntheticEvent,
+  useState,
+  Dispatch,
+  SetStateAction,
+  useEffect
+} from 'react';
 import { RegisterUI } from '@ui-pages';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from '../../services/store';
@@ -12,6 +19,10 @@ export const Register: FC = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const error = useSelector((state) => state.user.error);
+
+  useEffect(() => {
+    dispatch(resetError());
+  }, [dispatch]);
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();

--- a/src/pages/register/register.tsx
+++ b/src/pages/register/register.tsx
@@ -8,29 +8,52 @@ export const Register: FC = () => {
   const [userName, setUserName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [formError, setFormError] = useState('');
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const error = useSelector((state) => state.user.error);
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
+    if (!userName || !email || !password) {
+      setFormError('Заполните все поля');
+      return;
+    }
+
     dispatch(registerUser({ email, name: userName, password }))
       .unwrap()
       .then(() => {
         dispatch(resetError());
+        setFormError('');
         navigate('/', { replace: true });
-      });
+      })
+      .catch(() => {});
+  };
+
+  const handleEmailChange = (value: string) => {
+    setEmail(value);
+    if (formError) setFormError('');
+  };
+
+  const handlePasswordChange = (value: string) => {
+    setPassword(value);
+    if (formError) setFormError('');
+  };
+
+  const handleUserNameChange = (value: string) => {
+    setUserName(value);
+    if (formError) setFormError('');
   };
 
   return (
     <RegisterUI
-      errorText={error || ''}
+      errorText={error || formError}
       email={email}
       userName={userName}
       password={password}
-      setEmail={setEmail}
-      setPassword={setPassword}
-      setUserName={setUserName}
+      setEmail={handleEmailChange}
+      setPassword={handlePasswordChange}
+      setUserName={handleUserNameChange}
       handleSubmit={handleSubmit}
     />
   );

--- a/src/services/orders/slice.ts
+++ b/src/services/orders/slice.ts
@@ -59,9 +59,12 @@ const ordersSlice = createSlice({
   reducers: {
     clearCreatedOrder: (state) => {
       state.createdOrder = null;
+      state.orderRequest = false;
     },
     clearCurrentOrder: (state) => {
       state.currentOrder = null;
+      state.loading = false;
+      state.error = null;
     },
     setFeeds: (state, action: PayloadAction<TOrdersData>) => {
       state.feeds = action.payload;
@@ -95,9 +98,18 @@ const ordersSlice = createSlice({
       .addCase(
         fetchOrderInfo.fulfilled,
         (state, action: PayloadAction<TOrder>) => {
+          state.loading = false;
           state.currentOrder = action.payload;
         }
       )
+      .addCase(fetchOrderInfo.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchOrderInfo.rejected, (state) => {
+        state.loading = false;
+        state.error = 'Не удалось загрузить заказ';
+      })
       .addCase(createOrder.pending, (state) => {
         state.orderRequest = true;
         state.createdOrder = null;

--- a/src/services/orders/slice.ts
+++ b/src/services/orders/slice.ts
@@ -60,6 +60,9 @@ const ordersSlice = createSlice({
     clearCreatedOrder: (state) => {
       state.createdOrder = null;
     },
+    clearCurrentOrder: (state) => {
+      state.currentOrder = null;
+    },
     setFeeds: (state, action: PayloadAction<TOrdersData>) => {
       state.feeds = action.payload;
     },
@@ -113,7 +116,11 @@ const ordersSlice = createSlice({
   }
 });
 
-export const { clearCreatedOrder, setFeeds, setUserOrders } =
-  ordersSlice.actions;
+export const {
+  clearCreatedOrder,
+  clearCurrentOrder,
+  setFeeds,
+  setUserOrders
+} = ordersSlice.actions;
 
 export default ordersSlice.reducer;

--- a/src/services/orders/slice.ts
+++ b/src/services/orders/slice.ts
@@ -116,11 +116,7 @@ const ordersSlice = createSlice({
   }
 });
 
-export const {
-  clearCreatedOrder,
-  clearCurrentOrder,
-  setFeeds,
-  setUserOrders
-} = ordersSlice.actions;
+export const { clearCreatedOrder, clearCurrentOrder, setFeeds, setUserOrders } =
+  ordersSlice.actions;
 
 export default ordersSlice.reducer;

--- a/src/services/orders/slice.ts
+++ b/src/services/orders/slice.ts
@@ -66,6 +66,11 @@ const ordersSlice = createSlice({
       state.loading = false;
       state.error = null;
     },
+    setCurrentOrder: (state, action: PayloadAction<TOrder>) => {
+      state.currentOrder = action.payload;
+      state.loading = false;
+      state.error = null;
+    },
     setFeeds: (state, action: PayloadAction<TOrdersData>) => {
       state.feeds = action.payload;
     },
@@ -128,7 +133,12 @@ const ordersSlice = createSlice({
   }
 });
 
-export const { clearCreatedOrder, clearCurrentOrder, setFeeds, setUserOrders } =
-  ordersSlice.actions;
+export const {
+  clearCreatedOrder,
+  clearCurrentOrder,
+  setCurrentOrder,
+  setFeeds,
+  setUserOrders
+} = ordersSlice.actions;
 
 export default ordersSlice.reducer;

--- a/src/services/user/slice.ts
+++ b/src/services/user/slice.ts
@@ -28,11 +28,15 @@ export const registerUser = createAsyncThunk(
 
 export const loginUser = createAsyncThunk(
   'user/login',
-  async (data: TLoginData) => {
-    const res = await loginUserApi(data);
-    localStorage.setItem('refreshToken', res.refreshToken);
-    setCookie('accessToken', res.accessToken);
-    return res.user;
+  async (data: TLoginData, { rejectWithValue }) => {
+    try {
+      const res = await loginUserApi(data);
+      localStorage.setItem('refreshToken', res.refreshToken);
+      setCookie('accessToken', res.accessToken);
+      return res.user;
+    } catch (err) {
+      return rejectWithValue((err as { message?: string }).message);
+    }
   }
 );
 
@@ -90,9 +94,13 @@ const userSlice = createSlice({
         state.loading = false;
         state.user = action.payload;
       })
-      .addCase(loginUser.rejected, (state) => {
+      .addCase(loginUser.rejected, (state, action) => {
         state.loading = false;
-        state.error = 'Ошибка авторизации';
+        const msg = action.payload as string | undefined;
+        state.error =
+          msg === 'email or password are incorrect'
+            ? 'Неправильный пароль'
+            : 'Ошибка авторизации';
       })
       .addCase(registerUser.pending, (state) => {
         state.loading = true;

--- a/src/services/user/slice.ts
+++ b/src/services/user/slice.ts
@@ -89,6 +89,7 @@ const userSlice = createSlice({
       })
       .addCase(loginUser.pending, (state) => {
         state.loading = true;
+        state.error = null;
       })
       .addCase(loginUser.fulfilled, (state, action: PayloadAction<TUser>) => {
         state.loading = false;

--- a/src/services/user/slice.ts
+++ b/src/services/user/slice.ts
@@ -108,8 +108,17 @@ const userSlice = createSlice({
         state.loading = false;
         state.error = 'Ошибка регистрации';
       })
+      .addCase(updateUser.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(updateUser.fulfilled, (state, action: PayloadAction<TUser>) => {
+        state.loading = false;
         state.user = action.payload;
+      })
+      .addCase(updateUser.rejected, (state) => {
+        state.loading = false;
+        state.error = 'Ошибка обновления профиля';
       })
       .addCase(logout.fulfilled, (state) => {
         state.user = null;


### PR DESCRIPTION
## Summary
- clear order info state when modal unmounts and reload info if URL changes
- show order number in order info modal
- validate registration form fields and show error

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685adc261030832686e19c5d782aa1da