### PR TITLE
Fix auth check on order and cleanup

### DIFF
--- a/src/components/burger-constructor/burger-constructor.tsx
+++ b/src/components/burger-constructor/burger-constructor.tsx
@@ -1,4 +1,5 @@
 import { FC, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { TConstructorIngredient } from '@utils-types';
 import { BurgerConstructorUI } from '@ui';
 import { ConstructorItems } from '../ui/burger-constructor/type';
@@ -8,7 +9,9 @@ import { clearConstructor } from '../../services/constructor/slice';
 
 export const BurgerConstructor: FC = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { bun, ingredients } = useSelector((state) => state.burgerConstructor);
+  const user = useSelector((state) => state.user.user);
   const constructorItems: ConstructorItems = { bun, ingredients };
 
   const { orderRequest, createdOrder } = useSelector((state) => state.orders);
@@ -17,6 +20,10 @@ export const BurgerConstructor: FC = () => {
 
   const onOrderClick = () => {
     if (!constructorItems.bun || orderRequest) return;
+    if (!user) {
+      navigate('/login', { state: { from: '/' } });
+      return;
+    }
     const ids = [
       constructorItems.bun._id,
       ...constructorItems.ingredients.map((item) => item._id),

--- a/src/pages/not-fount-404/index.ts
+++ b/src/pages/not-fount-404/index.ts
@@ -1,1 +1,0 @@
-export { NotFound404 } from './not-fount-404';

--- a/src/pages/not-fount-404/not-fount-404.tsx
+++ b/src/pages/not-fount-404/not-fount-404.tsx
@@ -1,7 +1,0 @@
-import { FC } from 'react';
-
-export const NotFound404: FC = () => (
-  <h3 className={`pb-6 text text_type_main-large`}>
-    Страница не найдена. Ошибка 404.
-  </h3>
-);


### PR DESCRIPTION
## Summary
- ensure unauthenticated users are redirected to login when placing an order
- remove duplicate `not-fount-404` page

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685af7c1e1608326b33e61141e0b52fd