### PR TITLE
Implement auth persistence and clean up reducers

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -5,6 +5,10 @@ import {
   useLocation,
   Location
 } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useDispatch } from '../../services/store';
+import { fetchUser, setAuthChecked } from '../../services/user/slice';
+import { getCookie } from '../../utils/cookie';
 import {
   ConstructorPage,
   Feed,
@@ -30,6 +34,16 @@ import {
 const App = () => {
   const location = useLocation();
   const background = (location.state as { background?: Location })?.background;
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const hasToken = getCookie('accessToken') || localStorage.getItem('refreshToken');
+    if (hasToken) {
+      dispatch(fetchUser());
+    } else {
+      dispatch(setAuthChecked(true));
+    }
+  }, [dispatch]);
 
   return (
     <div className={styles.app}>

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -37,7 +37,8 @@ const App = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const hasToken = getCookie('accessToken') || localStorage.getItem('refreshToken');
+    const hasToken =
+      getCookie('accessToken') || localStorage.getItem('refreshToken');
     if (hasToken) {
       dispatch(fetchUser());
     } else {

--- a/src/components/protected-route/protected-route.tsx
+++ b/src/components/protected-route/protected-route.tsx
@@ -11,8 +11,12 @@ export const ProtectedRoute: FC<ProtectedRouteProps> = ({
   onlyUnAuth = false,
   element
 }) => {
-  const user = useSelector((state) => state.user.user);
+  const { user, isAuthChecked } = useSelector((state) => state.user);
   const location = useLocation();
+
+  if (!isAuthChecked) {
+    return null;
+  }
 
   if (onlyUnAuth && user) {
     const from = (location.state as { from?: string })?.from || '/';

--- a/src/pages/feed/feed.tsx
+++ b/src/pages/feed/feed.tsx
@@ -9,9 +9,7 @@ export const Feed: FC = () => {
   const { feeds, loading } = useSelector((state) => state.orders);
 
   useEffect(() => {
-    if (!feeds) {
-      dispatch(fetchFeeds());
-    }
+    dispatch(fetchFeeds());
     const wsUrl =
       process.env.BURGER_API_URL?.replace('https', 'wss').replace('/api', '') +
       '/orders/all';
@@ -27,7 +25,7 @@ export const Feed: FC = () => {
     return () => {
       socket.close();
     };
-  }, [dispatch, feeds]);
+  }, [dispatch]);
 
   if (loading || !feeds) {
     return <Preloader />;

--- a/src/pages/feed/feed.tsx
+++ b/src/pages/feed/feed.tsx
@@ -10,12 +10,10 @@ export const Feed: FC = () => {
 
   useEffect(() => {
     dispatch(fetchFeeds());
-    const wsUrl =
-      process.env.BURGER_API_URL?.replace('https', 'wss').replace('/api', '') +
-      '/orders/all';
-    const socket = new WebSocket(
-      wsUrl || 'wss://norma.nomoreparties.space/orders/all'
-    );
+    const wsBase = process.env.BURGER_API_URL
+      ? process.env.BURGER_API_URL.replace('https', 'wss').replace('/api', '')
+      : 'wss://norma.nomoreparties.space';
+    const socket = new WebSocket(`${wsBase}/orders/all`);
     socket.onmessage = (e) => {
       const data = JSON.parse(e.data);
       if (data.success) {

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,11 +1,4 @@
-import {
-  FC,
-  SyntheticEvent,
-  useState,
-  Dispatch,
-  SetStateAction,
-  useEffect
-} from 'react';
+import { FC, SyntheticEvent, useState, Dispatch, SetStateAction } from 'react';
 import { LoginUI } from '@ui-pages';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from '../../services/store';
@@ -18,10 +11,6 @@ export const Login: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const error = useSelector((state) => state.user.error);
-
-  useEffect(() => {
-    dispatch(resetError());
-  }, [dispatch]);
 
   const handleEmailChange: Dispatch<SetStateAction<string>> = (value) => {
     setEmail((prev) => (typeof value === 'function' ? value(prev) : value));

--- a/src/pages/profile-orders/profile-orders.tsx
+++ b/src/pages/profile-orders/profile-orders.tsx
@@ -8,16 +8,18 @@ import { getCookie } from '../../utils/cookie';
 export const ProfileOrders: FC = () => {
   const dispatch = useDispatch();
   const orders: TOrder[] = useSelector((state) => state.orders.userOrders);
+  const { isAuthChecked } = useSelector((state) => state.user);
 
   useEffect(() => {
+    if (!isAuthChecked) {
+      return;
+    }
     dispatch(fetchUserOrders());
     const token = getCookie('accessToken')?.replace('Bearer ', '');
-    const wsUrl =
-      process.env.BURGER_API_URL?.replace('https', 'wss').replace('/api', '') +
-      `/orders?token=${token}`;
-    const socket = new WebSocket(
-      wsUrl || 'wss://norma.nomoreparties.space/orders'
-    );
+    const wsBase = process.env.BURGER_API_URL
+      ? process.env.BURGER_API_URL.replace('https', 'wss').replace('/api', '')
+      : 'wss://norma.nomoreparties.space';
+    const socket = new WebSocket(`${wsBase}/orders?token=${token}`);
     socket.onmessage = (e) => {
       const data = JSON.parse(e.data);
       if (data.success) {
@@ -27,7 +29,7 @@ export const ProfileOrders: FC = () => {
     return () => {
       socket.close();
     };
-  }, [dispatch]);
+  }, [dispatch, isAuthChecked]);
 
   return <ProfileOrdersUI orders={orders} />;
 };

--- a/src/pages/profile-orders/profile-orders.tsx
+++ b/src/pages/profile-orders/profile-orders.tsx
@@ -9,9 +9,7 @@ export const ProfileOrders: FC = () => {
   const orders: TOrder[] = useSelector((state) => state.orders.userOrders);
 
   useEffect(() => {
-    if (!orders.length) {
-      dispatch(fetchUserOrders());
-    }
+    dispatch(fetchUserOrders());
     const wsUrl =
       process.env.BURGER_API_URL?.replace('https', 'wss').replace('/api', '') +
       `/orders?token=${localStorage.getItem('refreshToken')}`;
@@ -27,7 +25,7 @@ export const ProfileOrders: FC = () => {
     return () => {
       socket.close();
     };
-  }, [dispatch, orders.length]);
+  }, [dispatch]);
 
   return <ProfileOrdersUI orders={orders} />;
 };

--- a/src/pages/profile-orders/profile-orders.tsx
+++ b/src/pages/profile-orders/profile-orders.tsx
@@ -3,6 +3,7 @@ import { TOrder } from '@utils-types';
 import { FC, useEffect } from 'react';
 import { useDispatch, useSelector } from '../../services/store';
 import { fetchUserOrders, setUserOrders } from '../../services/orders/slice';
+import { getCookie } from '../../utils/cookie';
 
 export const ProfileOrders: FC = () => {
   const dispatch = useDispatch();
@@ -10,9 +11,10 @@ export const ProfileOrders: FC = () => {
 
   useEffect(() => {
     dispatch(fetchUserOrders());
+    const token = getCookie('accessToken')?.replace('Bearer ', '');
     const wsUrl =
       process.env.BURGER_API_URL?.replace('https', 'wss').replace('/api', '') +
-      `/orders?token=${localStorage.getItem('refreshToken')}`;
+      `/orders?token=${token}`;
     const socket = new WebSocket(
       wsUrl || 'wss://norma.nomoreparties.space/orders'
     );

--- a/src/services/constructor/slice.ts
+++ b/src/services/constructor/slice.ts
@@ -16,11 +16,19 @@ const constructorSlice = createSlice({
   name: 'burgerConstructor',
   initialState,
   reducers: {
-    addIngredient: (state, action: PayloadAction<TIngredient>) => {
-      if (action.payload.type === 'bun') {
-        state.bun = action.payload;
-      } else {
-        state.ingredients.push({ ...action.payload, id: uuidv4() });
+    addIngredient: {
+      reducer: (
+        state,
+        action: PayloadAction<TConstructorIngredient>
+      ) => {
+        if (action.payload.type === 'bun') {
+          state.bun = action.payload;
+        } else {
+          state.ingredients.push(action.payload);
+        }
+      },
+      prepare: (ingredient: TIngredient) => {
+        return { payload: { ...ingredient, id: uuidv4() } };
       }
     },
     removeIngredient: (state, action: PayloadAction<string>) => {

--- a/src/services/constructor/slice.ts
+++ b/src/services/constructor/slice.ts
@@ -17,19 +17,16 @@ const constructorSlice = createSlice({
   initialState,
   reducers: {
     addIngredient: {
-      reducer: (
-        state,
-        action: PayloadAction<TConstructorIngredient>
-      ) => {
+      reducer: (state, action: PayloadAction<TConstructorIngredient>) => {
         if (action.payload.type === 'bun') {
           state.bun = action.payload;
         } else {
           state.ingredients.push(action.payload);
         }
       },
-      prepare: (ingredient: TIngredient) => {
-        return { payload: { ...ingredient, id: uuidv4() } };
-      }
+      prepare: (ingredient: TIngredient) => ({
+        payload: { ...ingredient, id: uuidv4() }
+      })
     },
     removeIngredient: (state, action: PayloadAction<string>) => {
       state.ingredients = state.ingredients.filter(

--- a/src/services/ingredients/slice.ts
+++ b/src/services/ingredients/slice.ts
@@ -4,7 +4,7 @@ import { TIngredient } from '@utils-types';
 
 export const fetchIngredients = createAsyncThunk(
   'ingredients/fetch',
-  async () => await getIngredientsApi()
+  getIngredientsApi
 );
 
 interface IngredientsState {

--- a/src/services/orders/slice.ts
+++ b/src/services/orders/slice.ts
@@ -7,14 +7,11 @@ import {
 } from '@api';
 import { TOrdersData, TOrder } from '@utils-types';
 
-export const fetchFeeds = createAsyncThunk(
-  'orders/feeds',
-  async () => await getFeedsApi()
-);
+export const fetchFeeds = createAsyncThunk('orders/feeds', getFeedsApi);
 
 export const fetchUserOrders = createAsyncThunk(
   'orders/userOrders',
-  async () => await getOrdersApi()
+  getOrdersApi
 );
 
 export const fetchOrderInfo = createAsyncThunk(

--- a/src/services/user/slice.ts
+++ b/src/services/user/slice.ts
@@ -110,7 +110,7 @@ const userSlice = createSlice({
         const msg = action.payload as string | undefined;
         state.error =
           msg === 'email or password are incorrect'
-            ? 'Неправильный пароль'
+            ? 'Неверный Email или пароль'
             : 'Ошибка авторизации';
         state.isAuthChecked = true;
       })

--- a/src/services/user/slice.ts
+++ b/src/services/user/slice.ts
@@ -58,12 +58,14 @@ interface UserState {
   user: TUser | null;
   loading: boolean;
   error: string | null;
+  isAuthChecked: boolean;
 }
 
 const initialState: UserState = {
   user: null,
   loading: false,
-  error: null
+  error: null,
+  isAuthChecked: false
 };
 
 const userSlice = createSlice({
@@ -72,28 +74,36 @@ const userSlice = createSlice({
   reducers: {
     resetError: (state) => {
       state.error = null;
+    },
+    setAuthChecked: (state, action: PayloadAction<boolean>) => {
+      state.isAuthChecked = action.payload;
     }
   },
   extraReducers: (builder) => {
     builder
       .addCase(fetchUser.pending, (state) => {
         state.loading = true;
+        state.isAuthChecked = false;
       })
       .addCase(fetchUser.fulfilled, (state, action: PayloadAction<TUser>) => {
         state.loading = false;
         state.user = action.payload;
+        state.isAuthChecked = true;
       })
       .addCase(fetchUser.rejected, (state) => {
         state.loading = false;
         state.user = null;
+        state.isAuthChecked = true;
       })
       .addCase(loginUser.pending, (state) => {
         state.loading = true;
         state.error = null;
+        state.isAuthChecked = false;
       })
       .addCase(loginUser.fulfilled, (state, action: PayloadAction<TUser>) => {
         state.loading = false;
         state.user = action.payload;
+        state.isAuthChecked = true;
       })
       .addCase(loginUser.rejected, (state, action) => {
         state.loading = false;
@@ -102,20 +112,24 @@ const userSlice = createSlice({
           msg === 'email or password are incorrect'
             ? 'Неправильный пароль'
             : 'Ошибка авторизации';
+        state.isAuthChecked = true;
       })
       .addCase(registerUser.pending, (state) => {
         state.loading = true;
+        state.isAuthChecked = false;
       })
       .addCase(
         registerUser.fulfilled,
         (state, action: PayloadAction<TUser>) => {
           state.loading = false;
           state.user = action.payload;
+          state.isAuthChecked = true;
         }
       )
       .addCase(registerUser.rejected, (state) => {
         state.loading = false;
         state.error = 'Ошибка регистрации';
+        state.isAuthChecked = true;
       })
       .addCase(updateUser.pending, (state) => {
         state.loading = true;
@@ -131,10 +145,11 @@ const userSlice = createSlice({
       })
       .addCase(logout.fulfilled, (state) => {
         state.user = null;
+        state.isAuthChecked = true;
       });
   }
 });
 
-export const { resetError } = userSlice.actions;
+export const { resetError, setAuthChecked } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/src/utils/burger-api.ts
+++ b/src/utils/burger-api.ts
@@ -1,7 +1,8 @@
 import { setCookie, getCookie } from './cookie';
 import { TIngredient, TOrder, TOrdersData, TUser } from './types';
 
-const URL = process.env.BURGER_API_URL;
+const URL =
+  process.env.BURGER_API_URL ?? 'https://norma.nomoreparties.space/api';
 
 const checkResponse = <T>(res: Response): Promise<T> =>
   res.ok ? res.json() : res.json().then((err) => Promise.reject(err));


### PR DESCRIPTION
## Summary
- add `prepare` callback for constructor slice to keep reducers pure
- streamline async thunks
- introduce auth check state and auto-login logic
- wait for auth check in `ProtectedRoute`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd1dbeb083269dca084fe4a74580