### PR TITLE
Add unit and e2e tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4000',
+    setupNodeEvents() {
+      // implement node event listeners here
+    }
+  }
+});

--- a/cypress/e2e/constructor.cy.ts
+++ b/cypress/e2e/constructor.cy.ts
@@ -1,41 +1,47 @@
 describe('Constructor page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/ingredients', { fixture: 'ingredients.json' });
+    cy.intercept('GET', '**/ingredients', { fixture: 'ingredients.json' }).as(
+      'ingredients'
+    );
   });
 
   it('should add ingredient to constructor', () => {
     cy.visit('/');
-    cy.contains('button', 'Добавить').first().click();
+    cy.wait('@ingredients');
+    cy.contains('button', 'Добавить').eq(1).click();
     cy.contains('Выберите начинку').should('not.exist');
   });
 
   it('should open and close ingredient modal', () => {
     cy.visit('/');
+    cy.wait('@ingredients');
     cy.get('a').contains('Булка').click();
     cy.contains('Детали ингредиента');
     cy.contains('Булка');
-    cy.get('[class*=modal] button').click();
+    cy.get('#modals button').click();
     cy.contains('Детали ингредиента').should('not.exist');
 
     cy.get('a').contains('Булка').click();
-    cy.get('[class*=overlay]').click('topLeft');
+    cy.get('#modals .overlay').click('topLeft');
     cy.contains('Детали ингредиента').should('not.exist');
   });
 
   it('should create order and clear constructor', () => {
     cy.intercept('GET', '**/auth/user', { fixture: 'user.json' });
-    cy.intercept('POST', '**/orders', { fixture: 'order.json' });
+    cy.intercept('POST', '**/orders', { fixture: 'order.json' }).as('createOrder');
     cy.setCookie('accessToken', 'test');
     cy.window().then((win) => {
       win.localStorage.setItem('refreshToken', 'test');
     });
 
     cy.visit('/');
+    cy.wait('@ingredients');
     cy.contains('button', 'Добавить').eq(0).click();
     cy.contains('button', 'Добавить').eq(1).click();
     cy.contains('Оформить заказ').click();
+    cy.wait('@createOrder');
     cy.contains('1234');
-    cy.get('[class*=modal] button').click();
+    cy.get('#modals button').click();
     cy.contains('1234').should('not.exist');
     cy.contains('Выберите булки');
     cy.contains('Выберите начинку');

--- a/cypress/e2e/constructor.cy.ts
+++ b/cypress/e2e/constructor.cy.ts
@@ -1,0 +1,45 @@
+describe('Constructor page', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/ingredients', { fixture: 'ingredients.json' });
+  });
+
+  it('should add ingredient to constructor', () => {
+    cy.visit('/');
+    cy.contains('button', 'Добавить').first().click();
+    cy.contains('Выберите начинку').should('not.exist');
+  });
+
+  it('should open and close ingredient modal', () => {
+    cy.visit('/');
+    cy.get('a').contains('Булка').click();
+    cy.contains('Детали ингредиента');
+    cy.contains('Булка');
+    cy.get('[class*=modal] button').click();
+    cy.contains('Детали ингредиента').should('not.exist');
+
+    cy.get('a').contains('Булка').click();
+    cy.get('[class*=overlay]').click('topLeft');
+    cy.contains('Детали ингредиента').should('not.exist');
+  });
+
+  it('should create order and clear constructor', () => {
+    cy.intercept('GET', '**/auth/user', { fixture: 'user.json' });
+    cy.intercept('POST', '**/orders', { fixture: 'order.json' });
+    cy.setCookie('accessToken', 'test');
+    cy.window().then((win) => {
+      win.localStorage.setItem('refreshToken', 'test');
+    });
+
+    cy.visit('/');
+    cy.contains('button', 'Добавить').eq(0).click();
+    cy.contains('button', 'Добавить').eq(1).click();
+    cy.contains('Оформить заказ').click();
+    cy.contains('1234');
+    cy.get('[class*=modal] button').click();
+    cy.contains('1234').should('not.exist');
+    cy.contains('Выберите булки');
+    cy.contains('Выберите начинку');
+    cy.clearCookie('accessToken');
+    cy.window().then((win) => win.localStorage.clear());
+  });
+});

--- a/cypress/fixtures/ingredients.json
+++ b/cypress/fixtures/ingredients.json
@@ -1,0 +1,44 @@
+{
+  "success": true,
+  "data": [
+    {
+      "_id": "60d3b41abdacab0026a733c6",
+      "name": "Булка",
+      "type": "bun",
+      "proteins": 0,
+      "fat": 0,
+      "carbohydrates": 0,
+      "calories": 0,
+      "price": 1,
+      "image": "bun.png",
+      "image_large": "bun.png",
+      "image_mobile": "bun.png"
+    },
+    {
+      "_id": "60d3b41abdacab0026a733c8",
+      "name": "Соус",
+      "type": "sauce",
+      "proteins": 0,
+      "fat": 0,
+      "carbohydrates": 0,
+      "calories": 0,
+      "price": 2,
+      "image": "sauce.png",
+      "image_large": "sauce.png",
+      "image_mobile": "sauce.png"
+    },
+    {
+      "_id": "60d3b41abdacab0026a733c9",
+      "name": "Мясо",
+      "type": "main",
+      "proteins": 0,
+      "fat": 0,
+      "carbohydrates": 0,
+      "calories": 0,
+      "price": 3,
+      "image": "main.png",
+      "image_large": "main.png",
+      "image_mobile": "main.png"
+    }
+  ]
+}

--- a/cypress/fixtures/order.json
+++ b/cypress/fixtures/order.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "order": {
+    "_id": "order1",
+    "number": 1234,
+    "status": "done",
+    "name": "Test Burger",
+    "createdAt": "2021-01-01T00:00:00.000Z",
+    "updatedAt": "2021-01-01T00:00:00.000Z",
+    "ingredients": ["60d3b41abdacab0026a733c6"]
+  },
+  "name": "Test Burger"
+}

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "user": {
+    "email": "test@example.com",
+    "name": "Test"
+  }
+}

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,2 @@
+// Add custom commands here if needed
+export {};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@pages/(.*)$': '<rootDir>/src/pages/$1',
+    '^@components/(.*)$': '<rootDir>/src/components/$1',
+    '^@ui/(.*)$': '<rootDir>/src/components/ui/$1',
+    '^@ui-pages/(.*)$': '<rootDir>/src/components/ui/pages/$1',
+    '^@utils-types/(.*)$': '<rootDir>/src/utils/types/$1',
+    '^@api$': '<rootDir>/src/utils/burger-api.ts',
+    '^@slices/(.*)$': '<rootDir>/src/services/slices/$1',
+    '^@selectors/(.*)$': '<rootDir>/src/services/selectors/$1',
+    '\\.(css)$': 'jest-css-modules-transform'
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
     "build-storybook": "storybook build",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./src",
     "lint:fix": "npm run lint -- --fix",
-    "format": "prettier ./src --write"
+    "format": "prettier ./src --write",
+    "test": "jest",
+    "test:e2e": "cypress run"
   },
   "eslintConfig": {
     "extends": [

--- a/src/services/constructor/slice.test.ts
+++ b/src/services/constructor/slice.test.ts
@@ -1,0 +1,55 @@
+import reducer, { addIngredient, removeIngredient, moveIngredientUp } from './slice';
+import { TIngredient, TConstructorIngredient } from '../../utils/types';
+
+describe('constructor slice', () => {
+  const bun: TIngredient = {
+    _id: 'bun1',
+    name: 'bun',
+    type: 'bun',
+    proteins: 0,
+    fat: 0,
+    carbohydrates: 0,
+    calories: 0,
+    price: 1,
+    image: 'bun.png',
+    image_large: 'bun.png',
+    image_mobile: 'bun.png'
+  };
+
+  const ingredient: TIngredient = {
+    _id: 'ing1',
+    name: 'sauce',
+    type: 'sauce',
+    proteins: 0,
+    fat: 0,
+    carbohydrates: 0,
+    calories: 0,
+    price: 2,
+    image: 'sauce.png',
+    image_large: 'sauce.png',
+    image_mobile: 'sauce.png'
+  };
+
+  it('should handle addIngredient', () => {
+    const action = addIngredient(ingredient);
+    const state = reducer(undefined, action);
+    expect(state.ingredients).toHaveLength(1);
+    expect(state.ingredients[0]).toEqual(action.payload);
+  });
+
+  it('should handle removeIngredient', () => {
+    const addAction = addIngredient(ingredient);
+    const stateWithIngredient = reducer(undefined, addAction);
+    const removed = reducer(stateWithIngredient, removeIngredient(addAction.payload.id));
+    expect(removed.ingredients).toHaveLength(0);
+  });
+
+  it('should handle moveIngredientUp', () => {
+    const item1: TConstructorIngredient = { ...ingredient, id: '1' };
+    const item2: TConstructorIngredient = { ...ingredient, id: '2' };
+    const startState = { bun: bun, ingredients: [item1, item2] };
+    const moved = reducer(startState, moveIngredientUp(1));
+    expect(moved.ingredients[0].id).toBe('2');
+    expect(moved.ingredients[1].id).toBe('1');
+  });
+});

--- a/src/services/ingredients/slice.test.ts
+++ b/src/services/ingredients/slice.test.ts
@@ -1,0 +1,42 @@
+import reducer, { fetchIngredients } from './slice';
+import { TIngredient } from '../../utils/types';
+
+describe('ingredients slice', () => {
+  const initialState = { items: [], loading: false, error: null };
+
+  it('should handle fetchIngredients.pending', () => {
+    const state = reducer(initialState, { type: fetchIngredients.pending.type });
+    expect(state.loading).toBe(true);
+    expect(state.error).toBeNull();
+  });
+
+  it('should handle fetchIngredients.fulfilled', () => {
+    const ingredients: TIngredient[] = [
+      {
+        _id: '1',
+        name: 'bun',
+        type: 'bun',
+        proteins: 0,
+        fat: 0,
+        carbohydrates: 0,
+        calories: 0,
+        price: 1,
+        image: 'bun.png',
+        image_large: 'bun.png',
+        image_mobile: 'bun.png'
+      }
+    ];
+    const state = reducer(initialState, {
+      type: fetchIngredients.fulfilled.type,
+      payload: ingredients
+    });
+    expect(state.loading).toBe(false);
+    expect(state.items).toEqual(ingredients);
+  });
+
+  it('should handle fetchIngredients.rejected', () => {
+    const state = reducer(initialState, { type: fetchIngredients.rejected.type });
+    expect(state.loading).toBe(false);
+    expect(state.error).toBe('Не удалось загрузить ингредиенты');
+  });
+});

--- a/src/services/store.test.ts
+++ b/src/services/store.test.ts
@@ -1,0 +1,18 @@
+import { rootReducer } from './store';
+import ingredientsReducer from './ingredients/slice';
+import constructorReducer from './constructor/slice';
+import userReducer from './user/slice';
+import ordersReducer from './orders/slice';
+
+const initialState = {
+  ingredients: ingredientsReducer(undefined, { type: '' }),
+  burgerConstructor: constructorReducer(undefined, { type: '' }),
+  user: userReducer(undefined, { type: '' }),
+  orders: ordersReducer(undefined, { type: '' })
+};
+
+describe('rootReducer', () => {
+  it('should return initial state', () => {
+    expect(rootReducer(undefined, { type: 'UNKNOWN_ACTION' })).toEqual(initialState);
+  });
+});

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import {
   TypedUseSelectorHook,
   useDispatch as dispatchHook,
@@ -9,17 +9,19 @@ import constructorReducer from './constructor/slice';
 import userReducer from './user/slice';
 import ordersReducer from './orders/slice';
 
+export const rootReducer = combineReducers({
+  ingredients: ingredientsReducer,
+  burgerConstructor: constructorReducer,
+  user: userReducer,
+  orders: ordersReducer
+});
+
 const store = configureStore({
-  reducer: {
-    ingredients: ingredientsReducer,
-    burgerConstructor: constructorReducer,
-    user: userReducer,
-    orders: ordersReducer
-  },
+  reducer: rootReducer,
   devTools: process.env.NODE_ENV !== 'production'
 });
 
-export type RootState = ReturnType<typeof store.getState>;
+export type RootState = ReturnType<typeof rootReducer>;
 export type AppDispatch = typeof store.dispatch;
 
 export const useDispatch: () => AppDispatch = () => dispatchHook<AppDispatch>();


### PR DESCRIPTION
## Summary
- export `rootReducer` from store and configure reducers
- add jest config and npm scripts for running tests
- set up Cypress with baseUrl and fixtures
- write Jest tests for slices and rootReducer
- add Cypress test covering constructor page interactions

## Testing
- `npm test -- -w=1`
- `npm run test:e2e` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_685e138102e48326aa373628b330d37c