### PR TITLE
Add tests setup

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    setupNodeEvents() {
+      // implement node event listeners here
+    }
+  }
+});

--- a/cypress/e2e/constructor.cy.tsx
+++ b/cypress/e2e/constructor.cy.tsx
@@ -1,0 +1,49 @@
+describe('Burger constructor', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/ingredients', { fixture: 'ingredients.json' }).as('getIngredients');
+    cy.visit('/');
+    cy.wait('@getIngredients');
+  });
+
+  it('adds ingredients to constructor', () => {
+    cy.contains('Тестовая булка').parent().contains('Добавить').click();
+    cy.contains('Тестовый ингредиент').parent().contains('Добавить').click();
+    cy.get('[class*=burger_constructor]').should('contain', 'Тестовая булка');
+    cy.get('[class*=burger_constructor]').should('contain', 'Тестовый ингредиент');
+  });
+
+  it('opens and closes ingredient modal', () => {
+    cy.contains('Тестовый ингредиент').click();
+    cy.get('[class*=modal]').should('contain', 'Тестовый ингредиент');
+    cy.get('[class*=modal] button').click();
+    cy.get('[class*=modal]').should('not.exist');
+  });
+
+  it('closes ingredient modal by overlay', () => {
+    cy.contains('Тестовая булка').click();
+    cy.get('[class*=modal]').should('contain', 'Тестовая булка');
+    cy.get('[class*=overlay]').click('center');
+    cy.get('[class*=modal]').should('not.exist');
+  });
+
+  it('creates order and clears constructor', () => {
+    cy.intercept('GET', '**/auth/user', { fixture: 'user.json' }).as('getUser');
+    cy.intercept('POST', '**/orders', { fixture: 'order.json' }).as('createOrder');
+
+    cy.setCookie('accessToken', 'test');
+    cy.window().then((win) => {
+      win.localStorage.setItem('refreshToken', 'test');
+    });
+
+    cy.contains('Тестовая булка').parent().contains('Добавить').click();
+    cy.contains('Тестовый ингредиент').parent().contains('Добавить').click();
+
+    cy.contains('Оформить заказ').click();
+    cy.wait('@createOrder');
+    cy.get('[class*=modal]').should('contain', '12345');
+    cy.get('[class*=modal] button').click();
+    cy.get('[class*=modal]').should('not.exist');
+    cy.get('[class*=elements] li').should('have.length', 0);
+    cy.get('[class*=burger_constructor]').should('not.contain', 'Тестовая булка');
+  });
+});

--- a/cypress/fixtures/ingredients.json
+++ b/cypress/fixtures/ingredients.json
@@ -1,0 +1,31 @@
+{
+  "success": true,
+  "data": [
+    {
+      "_id": "1",
+      "name": "Тестовая булка",
+      "type": "bun",
+      "proteins": 0,
+      "fat": 0,
+      "carbohydrates": 0,
+      "calories": 0,
+      "price": 100,
+      "image": "bun.png",
+      "image_mobile": "bun.png",
+      "image_large": "bun.png"
+    },
+    {
+      "_id": "2",
+      "name": "Тестовый ингредиент",
+      "type": "main",
+      "proteins": 0,
+      "fat": 0,
+      "carbohydrates": 0,
+      "calories": 0,
+      "price": 50,
+      "image": "sauce.png",
+      "image_mobile": "sauce.png",
+      "image_large": "sauce.png"
+    }
+  ]
+}

--- a/cypress/fixtures/order.json
+++ b/cypress/fixtures/order.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "name": "Test order",
+  "order": {
+    "_id": "order1",
+    "status": "done",
+    "name": "Test order",
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z",
+    "number": 12345,
+    "ingredients": ["1", "2"]
+  }
+}

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "user": {
+    "email": "test@example.com",
+    "name": "Test User"
+  }
+}

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,1 @@
+// custom commands can be added here

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@pages(.*)$': '<rootDir>/src/pages$1',
+    '^@components(.*)$': '<rootDir>/src/components$1',
+    '^@ui(.*)$': '<rootDir>/src/components/ui$1',
+    '^@ui-pages(.*)$': '<rootDir>/src/components/ui/pages$1',
+    '^@utils-types(.*)$': '<rootDir>/src/utils/types$1',
+    '^@api(.*)$': '<rootDir>/src/utils/burger-api.ts$1',
+    '^@slices(.*)$': '<rootDir>/src/services/slices$1',
+    '^@selectors(.*)$': '<rootDir>/src/services/selectors$1',
+    '\\.(css|less|sass|scss)$': 'jest-css-modules-transform'
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  }
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
     "build-storybook": "storybook build",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./src",
     "lint:fix": "npm run lint -- --fix",
-    "format": "prettier ./src --write"
+    "format": "prettier ./src --write",
+    "test": "jest",
+    "cypress:run": "cypress run"
   },
   "eslintConfig": {
     "extends": [

--- a/src/services/__tests__/store.test.ts
+++ b/src/services/__tests__/store.test.ts
@@ -1,0 +1,17 @@
+import { rootReducer } from '../store';
+import constructorReducer from '../constructor/slice';
+import ingredientsReducer from '../ingredients/slice';
+import userReducer from '../user/slice';
+import ordersReducer from '../orders/slice';
+
+describe('rootReducer', () => {
+  it('should return initial state', () => {
+    const state = rootReducer(undefined, { type: 'UNKNOWN_ACTION' });
+    expect(state).toEqual({
+      ingredients: ingredientsReducer(undefined, { type: 'UNKNOWN_ACTION' }),
+      burgerConstructor: constructorReducer(undefined, { type: 'UNKNOWN_ACTION' }),
+      user: userReducer(undefined, { type: 'UNKNOWN_ACTION' }),
+      orders: ordersReducer(undefined, { type: 'UNKNOWN_ACTION' })
+    });
+  });
+});

--- a/src/services/constructor/__tests__/slice.test.ts
+++ b/src/services/constructor/__tests__/slice.test.ts
@@ -1,0 +1,55 @@
+import reducer, { addIngredient, removeIngredient, moveIngredientUp } from '../slice';
+import { TIngredient } from '@utils-types';
+
+jest.mock('uuid', () => ({ v4: () => '123' }));
+
+describe('constructor slice', () => {
+  const bun: TIngredient = {
+    _id: '1',
+    name: 'bun',
+    type: 'bun',
+    proteins: 0,
+    fat: 0,
+    carbohydrates: 0,
+    calories: 0,
+    price: 1,
+    image: '',
+    image_mobile: '',
+    image_large: ''
+  };
+
+  const sauce: TIngredient = {
+    _id: '2',
+    name: 'sauce',
+    type: 'sauce',
+    proteins: 0,
+    fat: 0,
+    carbohydrates: 0,
+    calories: 0,
+    price: 2,
+    image: '',
+    image_mobile: '',
+    image_large: ''
+  };
+
+  it('should handle addIngredient', () => {
+    let state = reducer(undefined, addIngredient(bun));
+    expect(state.bun?._id).toBe('1');
+    state = reducer(state, addIngredient(sauce));
+    expect(state.ingredients.length).toBe(1);
+  });
+
+  it('should handle removeIngredient', () => {
+    const initial = reducer(undefined, addIngredient(sauce));
+    const state = reducer(initial, removeIngredient('123'));
+    expect(state.ingredients.length).toBe(0);
+  });
+
+  it('should handle moveIngredientUp', () => {
+    const firstState = reducer(undefined, addIngredient(sauce));
+    const secondState = reducer(firstState, addIngredient({ ...sauce, _id: '3' }));
+    const moved = reducer(secondState, moveIngredientUp(1));
+    expect(moved.ingredients[0]._id).toBe('3');
+    expect(moved.ingredients[1]._id).toBe('2');
+  });
+});

--- a/src/services/ingredients/__tests__/slice.test.ts
+++ b/src/services/ingredients/__tests__/slice.test.ts
@@ -1,0 +1,38 @@
+import reducer, { fetchIngredients } from '../slice';
+import { TIngredient } from '@utils-types';
+
+describe('ingredients slice', () => {
+  const initial = { items: [], loading: false, error: null };
+  const payload: TIngredient[] = [
+    {
+      _id: '1',
+      name: 'bun',
+      type: 'bun',
+      proteins: 0,
+      fat: 0,
+      carbohydrates: 0,
+      calories: 0,
+      price: 1,
+      image: '',
+      image_mobile: '',
+      image_large: ''
+    }
+  ];
+
+  it('handles pending', () => {
+    const state = reducer(initial, fetchIngredients.pending('req'));
+    expect(state.loading).toBe(true);
+  });
+
+  it('handles fulfilled', () => {
+    const state = reducer(initial, fetchIngredients.fulfilled(payload, 'req'));
+    expect(state.loading).toBe(false);
+    expect(state.items).toEqual(payload);
+  });
+
+  it('handles rejected', () => {
+    const state = reducer(initial, fetchIngredients.rejected(null, 'req'));
+    expect(state.loading).toBe(false);
+    expect(state.error).toBe('Не удалось загрузить ингредиенты');
+  });
+});

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import {
   TypedUseSelectorHook,
   useDispatch as dispatchHook,
@@ -9,13 +9,15 @@ import constructorReducer from './constructor/slice';
 import userReducer from './user/slice';
 import ordersReducer from './orders/slice';
 
+export const rootReducer = combineReducers({
+  ingredients: ingredientsReducer,
+  burgerConstructor: constructorReducer,
+  user: userReducer,
+  orders: ordersReducer
+});
+
 const store = configureStore({
-  reducer: {
-    ingredients: ingredientsReducer,
-    burgerConstructor: constructorReducer,
-    user: userReducer,
-    orders: ordersReducer
-  },
+  reducer: rootReducer,
   devTools: process.env.NODE_ENV !== 'production'
 });
 


### PR DESCRIPTION
## Summary
- export `rootReducer`
- configure Jest with ts-jest
- add Cypress config and fixtures
- write Cypress tests for constructor page
- implement Jest unit tests for reducers
- add scripts for running tests

## Testing
- `npm test`
- `npm run cypress:run` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_685e24ac970c832680816615f0b3b151